### PR TITLE
Test-mcp-ui

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -164,7 +164,7 @@ async function main(): Promise<void> {
   const server = new Server(
     {
       name: "UseKeen Documentation MCP Server",
-      version: "1.0.0",
+      version: "1.2.3",
     },
     {
       capabilities: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "usekeen-mcp",
-  "version": "1.2.2",
+  "version": "1.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "usekeen-mcp",
-      "version": "1.2.2",
+      "version": "1.2.4",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.10.2",
-        "zod": "^3.22.4"
+        "zod": "^3.22.4",
+        "zod-to-json-schema": "^3.21.1"
       },
       "bin": {
         "usekeen-mcp": "dist/index.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "usekeen-mcp",
-  "version": "1.0.1",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "usekeen-mcp",
-      "version": "1.0.1",
+      "version": "1.2.2",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.10.2"
+        "@modelcontextprotocol/sdk": "^1.10.2",
+        "zod": "^3.22.4"
       },
       "bin": {
         "usekeen-mcp": "dist/index.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "usekeen-mcp",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "MCP server for UseKeen package documentation search",
   "main": "dist/index.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "usekeen-mcp",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "MCP server for UseKeen package documentation search",
   "main": "dist/index.js",
   "type": "module",
@@ -15,7 +15,8 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.10.2",
-    "zod": "^3.22.4"
+    "zod": "^3.22.4",
+    "zod-to-json-schema": "^3.21.1"
   },
   "devDependencies": {
     "typescript": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "usekeen-mcp",
-  "version": "1.2.0",
+  "version": "1.2.2",
   "description": "MCP server for UseKeen package documentation search",
   "main": "dist/index.js",
   "type": "module",
@@ -14,7 +14,8 @@
     "prepare": "npm run build"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.10.2"
+    "@modelcontextprotocol/sdk": "^1.10.2",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "typescript": "^5.0.0",


### PR DESCRIPTION
This commit refactors the server to provide its list of tools dynamically instead of defining them statically at initialization.

A request handler for `ListToolsRequestSchema` is now implemented to return the available tools. This aligns the server with the standard Model Context Protocol, allowing clients to query for capabilities.

This change also improves type safety by:
- Importing `ToolSchema` from the SDK.
- Adding the `zod-to-json-schema` dependency to correctly generate the tool input schemas.